### PR TITLE
Persist per-user theme mode and tint across app pages

### DIFF
--- a/app/api/invite/accept/route.ts
+++ b/app/api/invite/accept/route.ts
@@ -6,6 +6,7 @@ import { applySessionCookie, createAppSession } from '@utils/auth-session';
 import { AppRole } from '@utils/authz';
 import { getDbPool } from '@utils/db';
 import { hashPassword } from '@utils/password';
+import { applyThemePreferencesCookie, loadUserThemePreferences } from '@utils/theme-preferences-server';
 
 export const runtime = 'nodejs';
 
@@ -176,16 +177,19 @@ export async function POST(request: NextRequest) {
     await client.query('commit');
 
     const sessionToken = await createAppSession(createdUser.id);
+    const themePreferences = await loadUserThemePreferences(createdUser.id);
     const response = NextResponse.json({
       success: true,
       user: {
         id: createdUser.id,
         username: createdUser.username,
         role,
+        themePreferences,
       },
     });
 
     applySessionCookie(response, sessionToken);
+    applyThemePreferencesCookie(response, themePreferences);
 
     return response;
   } catch (error: any) {

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 
 import { getAppSession } from '@utils/auth-session';
 import { getRolePermissions } from '@utils/authz';
+import { applyThemePreferencesCookie, saveUserThemePreferences } from '@utils/theme-preferences-server';
+import { normalizeThemePreferences } from '@utils/theme-preferences';
 
 export const runtime = 'nodejs';
 
@@ -19,9 +21,51 @@ export async function GET() {
       role: session.role,
       effectiveRole: session.effectiveRole,
       assumedRole: session.assumedRole,
+      themePreferences: session.themePreferences,
       permissions: session.permissions,
       basePermissions: getRolePermissions(session.role),
       canOverrideSessionRole: session.role === 'superadmin',
     },
   });
+}
+
+interface MeUpdateBody {
+  themePreferences?: {
+    mode?: string;
+    tint?: string;
+  };
+}
+
+export async function PATCH(request: Request) {
+  const session = await getAppSession();
+
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = ((await request.json().catch(() => ({}))) || {}) as MeUpdateBody;
+  if (!body.themePreferences) {
+    return NextResponse.json({ error: 'Theme preferences are required.' }, { status: 400 });
+  }
+
+  const themePreferences = normalizeThemePreferences(body.themePreferences);
+  await saveUserThemePreferences(session.userId, themePreferences);
+
+  const response = NextResponse.json({
+    success: true,
+    user: {
+      id: session.userId,
+      username: session.username,
+      role: session.role,
+      effectiveRole: session.effectiveRole,
+      assumedRole: session.assumedRole,
+      themePreferences,
+      permissions: session.permissions,
+      basePermissions: getRolePermissions(session.role),
+      canOverrideSessionRole: session.role === 'superadmin',
+    },
+  });
+
+  applyThemePreferencesCookie(response, themePreferences);
+  return response;
 }

--- a/app/api/signin/route.ts
+++ b/app/api/signin/route.ts
@@ -4,6 +4,7 @@ import { applySessionCookie, createAppSession } from '@utils/auth-session';
 import { normalizeAppRole } from '@utils/authz';
 import { dbQuery } from '@utils/db';
 import { hashPassword, verifyPassword } from '@utils/password';
+import { applyThemePreferencesCookie, loadUserThemePreferences } from '@utils/theme-preferences-server';
 
 export const runtime = 'nodejs';
 
@@ -133,6 +134,7 @@ export async function POST(request: NextRequest) {
     }
 
     const token = await createAppSession(user.id);
+    const themePreferences = await loadUserThemePreferences(user.id);
     const response = new NextResponse(
       JSON.stringify({
         success: true,
@@ -140,6 +142,7 @@ export async function POST(request: NextRequest) {
           id: user.id,
           username: user.username,
           role: normalizeAppRole(user.role, 'readonly'),
+          themePreferences,
         },
       }),
       {
@@ -149,6 +152,7 @@ export async function POST(request: NextRequest) {
     );
 
     applySessionCookie(response, token);
+    applyThemePreferencesCookie(response, themePreferences);
 
     return response;
   } catch (error: any) {

--- a/app/api/signout/route.ts
+++ b/app/api/signout/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 
 import { clearSessionCookie, readSessionTokenFromCookie, revokeAppSessionByToken } from '@utils/auth-session';
 import { getRequestOrigin } from '@utils/billing-config';
+import { clearThemePreferencesCookie } from '@utils/theme-preferences-server';
 
 export const runtime = 'nodejs';
 
@@ -32,6 +33,7 @@ export async function POST() {
 
   const response = NextResponse.json({ success: true });
   clearSessionCookie(response);
+  clearThemePreferencesCookie(response);
 
   return response;
 }
@@ -46,5 +48,6 @@ export async function GET(request: Request) {
 
   const response = NextResponse.redirect(redirectUrl);
   clearSessionCookie(response);
+  clearThemePreferencesCookie(response);
   return response;
 }

--- a/app/doors/layout.tsx
+++ b/app/doors/layout.tsx
@@ -1,11 +1,3 @@
-import Providers from '@components/Providers';
-
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="en-us">
-      <body className="theme-light">
-        <Providers>{children}</Providers>
-      </body>
-    </html>
-  );
+  return children;
 }

--- a/app/examples/page.tsx
+++ b/app/examples/page.tsx
@@ -73,7 +73,7 @@ import TextArea from '@components/TextArea';
 import TreeView from '@components/TreeView';
 import UpdatingDataTable from '@components/examples/UpdatingDataTable';
 
-export const dynamic = 'force-static';
+export const dynamic = 'force-dynamic';
 
 // NOTE(jimmylee)
 // https://nextjs.org/docs/app/api-reference/functions/generate-metadata

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -97,8 +97,7 @@ export default function JoinPage() {
         throw new Error(data?.error || 'Unable to accept invite.');
       }
 
-      router.push('/');
-      router.refresh();
+      window.location.assign('/');
     } catch (submitError: any) {
       setError(submitError?.message || 'Unable to accept invite.');
     } finally {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,17 @@
 import Providers from '@components/Providers';
 import { PricingProvider } from '@components/PricingProvider';
+import { readThemePreferencesFromCookie } from '@utils/theme-preferences-server';
+import { themePreferencesToBodyClassName } from '@utils/theme-preferences';
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export const dynamic = 'force-dynamic';
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const initialThemePreferences = await readThemePreferencesFromCookie();
+
   return (
     <html lang="en-us">
-      <body className="theme-light">
-        <Providers>
+      <body className={themePreferencesToBodyClassName(initialThemePreferences)}>
+        <Providers initialThemePreferences={initialThemePreferences}>
           <PricingProvider>{children}</PricingProvider>
         </Providers>
       </body>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,7 +3,6 @@
 import '@root/global.scss';
 
 import { FormEvent, useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
 
 import Button from '@components/Button';
 import Card from '@components/Card';
@@ -14,8 +13,6 @@ import Input from '@components/Input';
 import Text from '@components/Text';
 
 export default function LoginPage() {
-  const router = useRouter();
-
   const [nextPath, setNextPath] = useState('/');
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -58,8 +55,7 @@ export default function LoginPage() {
         throw new Error(data?.error || 'Unable to sign in.');
       }
 
-      router.push(nextPath || '/');
-      router.refresh();
+      window.location.assign(nextPath || '/');
     } catch (submitError: any) {
       setError(submitError?.message || 'Unable to sign in.');
     } finally {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -17,15 +17,18 @@ import Table from '@components/Table';
 import TableColumn from '@components/TableColumn';
 import TableRow from '@components/TableRow';
 import Text from '@components/Text';
+import { useThemePreferences } from '@components/ThemeProvider';
 
 import { usePricing } from '@components/PricingProvider';
 import { EdgeworkType, GlassThickness, GlassType } from '@utils/calculations';
+import { THEME_MODE_OPTIONS, THEME_TINT_OPTIONS } from '@utils/theme-preferences';
 
 const navigationItems = APP_NAVIGATION_ITEMS;
 
 export default function PricingSettings() {
   const router = useRouter();
   const { pricingData, updatePricingData, resetToDefaults } = usePricing();
+  const { themePreferences, isSaving, error: themeError } = useThemePreferences();
   const [basePrices, setBasePrices] = useState(pricingData.basePrices);
   const [edgeworkPrices, setEdgeworkPrices] = useState(pricingData.edgeworkPrices);
   const [otherPrices, setOtherPrices] = useState(pricingData.otherPrices);
@@ -88,6 +91,8 @@ export default function PricingSettings() {
   const glassTypes: GlassType[] = ['Clear', 'Green', 'Grey', 'Dark Grey', 'Super Grey'];
   const edgeworkTypes: EdgeworkType[] = ['ROUGH ARRIS', 'FLAT GRIND - STRAIGHT', 'FLAT GRIND - CURVED', 'FLAT POLISH - STRAIGHT', 'FLAT POLISH - CURVED'];
   const thicknesses: GlassThickness[] = [4, 5, 6, 8, 10, 12];
+  const currentModeLabel = THEME_MODE_OPTIONS.find((option) => option.value === themePreferences.mode)?.label || 'Light';
+  const currentTintLabel = THEME_TINT_OPTIONS.find((option) => option.value === themePreferences.tint)?.label || 'None';
 
   return (
     <AppFrame
@@ -116,9 +121,17 @@ export default function PricingSettings() {
           )}
 
           <Card title="APPEARANCE">
-            <Text>Theme and font controls are available here only, to keep the rest of the app clean.</Text>
+            <Text>Theme, tint, and font controls save automatically for the signed-in user and apply across app pages.</Text>
             <br />
             <DefaultActionBar />
+            <br />
+            {themeError ? (
+              <Text>
+                <span className="status-error">{themeError}</span>
+              </Text>
+            ) : (
+              <Text style={{ opacity: 0.75 }}>{isSaving ? 'Saving theme preferences...' : `Saved: ${currentModeLabel} / ${currentTintLabel}`}</Text>
+            )}
           </Card>
 
           <Card title="HOSTING BILLING">

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -2,14 +2,21 @@
 
 import * as React from 'react';
 
+import { ThemeProvider } from '@components/ThemeProvider';
 import { ModalProvider } from '@components/page/ModalContext';
+import { ThemePreferences } from '@utils/theme-preferences';
 
 interface ProvidersProps {
   children: React.ReactNode;
+  initialThemePreferences: ThemePreferences;
 }
 
-const Providers: React.FC<ProvidersProps> = ({ children }) => {
-  return <ModalProvider>{children}</ModalProvider>;
+const Providers: React.FC<ProvidersProps> = ({ children, initialThemePreferences }) => {
+  return (
+    <ThemeProvider initialThemePreferences={initialThemePreferences}>
+      <ModalProvider>{children}</ModalProvider>
+    </ThemeProvider>
+  );
 };
 
 export default Providers;

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import * as React from 'react';
+
+import { ThemeMode, ThemePreferences, ThemeTint, applyThemePreferencesToDocument, normalizeThemePreferences } from '@utils/theme-preferences';
+
+interface ThemeContextValue {
+  themePreferences: ThemePreferences;
+  isSaving: boolean;
+  error: string | null;
+  setThemeMode: (mode: ThemeMode) => Promise<void>;
+  setThemeTint: (tint: ThemeTint) => Promise<void>;
+}
+
+const ThemeContext = React.createContext<ThemeContextValue | null>(null);
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+  initialThemePreferences: ThemePreferences;
+}
+
+interface ThemeUpdateResponse {
+  user?: {
+    themePreferences?: Partial<ThemePreferences>;
+  };
+  error?: string;
+}
+
+export function ThemeProvider({ children, initialThemePreferences }: ThemeProviderProps) {
+  const initialState = React.useRef(normalizeThemePreferences(initialThemePreferences));
+  const [themePreferences, setThemePreferences] = React.useState<ThemePreferences>(initialState.current);
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const themePreferencesRef = React.useRef(themePreferences);
+  const saveRequestId = React.useRef(0);
+
+  React.useEffect(() => {
+    themePreferencesRef.current = themePreferences;
+    applyThemePreferencesToDocument(themePreferences);
+  }, [themePreferences]);
+
+  React.useEffect(() => {
+    const nextThemePreferences = normalizeThemePreferences(initialThemePreferences);
+    initialState.current = nextThemePreferences;
+    setThemePreferences(nextThemePreferences);
+    setError(null);
+  }, [initialThemePreferences]);
+
+  async function persistThemePreferences(nextThemePreferences: ThemePreferences) {
+    const previousThemePreferences = themePreferencesRef.current;
+    const requestId = saveRequestId.current + 1;
+    saveRequestId.current = requestId;
+
+    setThemePreferences(nextThemePreferences);
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/me', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          themePreferences: nextThemePreferences,
+        }),
+      });
+
+      const data = ((await response.json().catch(() => ({}))) || {}) as ThemeUpdateResponse;
+      if (!response.ok) {
+        throw new Error(data.error || 'Unable to save theme preferences.');
+      }
+
+      if (requestId !== saveRequestId.current) {
+        return;
+      }
+
+      const savedThemePreferences = normalizeThemePreferences(data.user?.themePreferences || nextThemePreferences);
+      setThemePreferences(savedThemePreferences);
+    } catch (saveError: any) {
+      if (requestId !== saveRequestId.current) {
+        return;
+      }
+
+      setThemePreferences(previousThemePreferences);
+      setError(saveError?.message || 'Unable to save theme preferences.');
+    } finally {
+      if (requestId === saveRequestId.current) {
+        setIsSaving(false);
+      }
+    }
+  }
+
+  async function setThemeMode(mode: ThemeMode) {
+    await persistThemePreferences({
+      ...themePreferencesRef.current,
+      mode,
+    });
+  }
+
+  async function setThemeTint(tint: ThemeTint) {
+    await persistThemePreferences({
+      ...themePreferencesRef.current,
+      tint,
+    });
+  }
+
+  return <ThemeContext.Provider value={{ themePreferences, isSaving, error, setThemeMode, setThemeTint }}>{children}</ThemeContext.Provider>;
+}
+
+export function useThemePreferences(): ThemeContextValue {
+  const context = React.useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useThemePreferences must be used within ThemeProvider');
+  }
+
+  return context;
+}

--- a/components/page/DefaultActionBar.tsx
+++ b/components/page/DefaultActionBar.tsx
@@ -5,11 +5,12 @@ import styles from '@components/page/DefaultActionBar.module.scss';
 import * as React from 'react';
 import * as Utilities from '@common/utilities';
 
+import { useThemePreferences } from '@components/ThemeProvider';
 import { toggleDebugGrid } from '@components/DebugGrid';
 import { useHotkeys } from '@modules/hotkeys';
 
 import ActionBar from '@components/ActionBar';
-import ButtonGroup from '@components/ButtonGroup';
+import { THEME_MODE_OPTIONS, THEME_TINT_OPTIONS } from '@utils/theme-preferences';
 
 function isElement(target: EventTarget | null): target is Element {
   return target instanceof Element;
@@ -116,30 +117,10 @@ interface DefaultActionBarProps {
 }
 
 const DefaultActionBar: React.FC<DefaultActionBarProps> = ({ floating = false, items = [] }) => {
-  const [isGrid, setGrid] = React.useState(false);
+  const { themePreferences, setThemeMode, setThemeTint } = useThemePreferences();
   useHotkeys('ctrl+g', () => toggleDebugGrid());
 
   useGlobalNavigationHotkeys();
-
-  React.useEffect(() => {
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-
-    const applyTheme = (e: MediaQueryList | MediaQueryListEvent) => {
-      if (e.matches) {
-        Utilities.onHandleAppearanceChange('theme-dark');
-      } else {
-        Utilities.onHandleAppearanceChange('');
-      }
-    };
-
-    applyTheme(prefersDark);
-
-    prefersDark.addEventListener('change', applyTheme);
-
-    return () => {
-      prefersDark.removeEventListener('change', applyTheme);
-    };
-  }, []);
 
   const rootClassName = floating ? `${styles.root} ${styles.floating}` : styles.root;
 
@@ -336,67 +317,23 @@ const DefaultActionBar: React.FC<DefaultActionBarProps> = ({ floating = false, i
           },
           {
             hotkey: '⌃+A',
-            body: 'Appearance',
+            body: 'Theme',
             openHotkey: 'ctrl+a',
-            items: [
-              {
-                icon: '⊹',
-                children: 'Light',
-                onClick: () => Utilities.onHandleAppearanceChange(''),
-              },
-              {
-                icon: '⊹',
-                children: 'Dark',
-                onClick: () => Utilities.onHandleAppearanceChange('theme-dark'),
-              },
-            ],
+            items: THEME_MODE_OPTIONS.map((option) => ({
+              icon: themePreferences.mode === option.value ? '◉' : '◌',
+              children: option.label,
+              onClick: () => setThemeMode(option.value),
+            })),
           },
           {
             hotkey: '⌃+T',
-            body: 'Mode',
+            body: 'Tint',
             openHotkey: 'ctrl+t',
-            items: [
-              {
-                icon: '⊹',
-                children: 'None',
-                onClick: () => Utilities.onHandleAppearanceModeChange(''),
-              },
-              {
-                icon: '⊹',
-                children: 'Blue',
-                onClick: () => Utilities.onHandleAppearanceModeChange('tint-blue'),
-              },
-              {
-                icon: '⊹',
-                children: 'Green',
-                onClick: () => Utilities.onHandleAppearanceModeChange('tint-green'),
-              },
-              {
-                icon: '⊹',
-                children: 'Orange',
-                onClick: () => Utilities.onHandleAppearanceModeChange('tint-orange'),
-              },
-              {
-                icon: '⊹',
-                children: 'Purple',
-                onClick: () => Utilities.onHandleAppearanceModeChange('tint-purple'),
-              },
-              {
-                icon: '⊹',
-                children: 'Red',
-                onClick: () => Utilities.onHandleAppearanceModeChange('tint-red'),
-              },
-              {
-                icon: '⊹',
-                children: 'Yellow',
-                onClick: () => Utilities.onHandleAppearanceModeChange('tint-yellow'),
-              },
-              {
-                icon: '⊹',
-                children: 'Pink',
-                onClick: () => Utilities.onHandleAppearanceModeChange('tint-pink'),
-              },
-            ],
+            items: THEME_TINT_OPTIONS.map((option) => ({
+              icon: themePreferences.tint === option.value ? '◉' : '◌',
+              children: option.label,
+              onClick: () => setThemeTint(option.value),
+            })),
           },
           {
             hotkey: '⌃+G',

--- a/docs/order-management-schema.sql
+++ b/docs/order-management-schema.sql
@@ -17,14 +17,38 @@ create table if not exists users (
   username text not null unique,
   password_hash text not null,
   role text not null check (role in ('superadmin', 'admin', 'standard', 'readonly')),
+  theme_mode text not null default 'light' check (theme_mode in ('light', 'dark', 'system')),
+  theme_tint text not null default 'none' check (theme_tint in ('none', 'blue', 'green', 'orange', 'purple', 'red', 'yellow', 'pink')),
   is_active boolean not null default true,
   created_at timestamptz not null default now()
 );
 
 do $$
 begin
+  alter table users add column if not exists theme_mode text;
+  alter table users add column if not exists theme_tint text;
+
+  update users
+  set theme_mode = 'light'
+  where theme_mode is null
+    or theme_mode not in ('light', 'dark', 'system');
+
+  update users
+  set theme_tint = 'none'
+  where theme_tint is null
+    or theme_tint not in ('none', 'blue', 'green', 'orange', 'purple', 'red', 'yellow', 'pink');
+
+  alter table users alter column theme_mode set default 'light';
+  alter table users alter column theme_mode set not null;
+  alter table users alter column theme_tint set default 'none';
+  alter table users alter column theme_tint set not null;
+
   alter table users drop constraint if exists users_role_check;
   alter table users add constraint users_role_check check (role in ('superadmin', 'admin', 'standard', 'readonly'));
+  alter table users drop constraint if exists users_theme_mode_check;
+  alter table users add constraint users_theme_mode_check check (theme_mode in ('light', 'dark', 'system'));
+  alter table users drop constraint if exists users_theme_tint_check;
+  alter table users add constraint users_theme_tint_check check (theme_tint in ('none', 'blue', 'green', 'orange', 'purple', 'red', 'yellow', 'pink'));
 exception
   when undefined_table then
     null;

--- a/global.scss
+++ b/global.scss
@@ -206,6 +206,42 @@ body.theme-dark {
   --theme-focused-foreground-subdued: var(--color-daybreak-10-5);
 }
 
+body.theme-system {
+  --theme-overlay: var(--color-black-100-4);
+  --theme-background: var(--color-white);
+  --theme-background-modal: var(--color-gray-20);
+  --theme-background-modal-footer: var(--color-gray-40);
+  --theme-background-input: var(--color-gray-10);
+  --theme-border: var(--color-gray-20);
+  --theme-border-subdued: var(--color-gray-40-2);
+  --theme-text: var(--color-black-100);
+  --theme-button: var(--color-black-100);
+  --theme-button-text: var(--color-white);
+  --theme-button-foreground: var(--color-gray-30);
+  --theme-button-background: var(--color-gray-20);
+  --theme-focused-foreground: var(--color-neon-green-50);
+  --theme-focused-foreground-subdued: var(--color-neon-green-50-5);
+}
+
+@media (prefers-color-scheme: dark) {
+  body.theme-system {
+    --theme-overlay: var(--color-black-100-4);
+    --theme-background: var(--color-black-100);
+    --theme-background-modal: var(--color-gray-80);
+    --theme-background-modal-footer: var(--color-gray-70);
+    --theme-background-input: var(--color-gray-60);
+    --theme-border: var(--color-gray-80);
+    --theme-border-subdued: var(--color-gray-70-3);
+    --theme-text: var(--color-white);
+    --theme-button: var(--color-white);
+    --theme-button-text: var(--color-black-100);
+    --theme-button-foreground: var(--color-gray-90);
+    --theme-button-background: var(--color-gray-80);
+    --theme-focused-foreground: var(--color-daybreak-10);
+    --theme-focused-foreground-subdued: var(--color-daybreak-10-5);
+  }
+}
+
 body.tint-green {
   --tint: #39ff44;
 }
@@ -264,6 +300,40 @@ body.theme-dark[class*='tint-'] {
   --theme-button-background: oklch(from var(--tint) 0.3 calc(c * 0.2) h);
   --theme-focused-foreground: oklch(from var(--tint) 0.7 c h);
   --theme-focused-foreground-subdued: oklch(from var(--tint) 0.7 c h / 0.5);
+}
+
+body.theme-system[class*='tint-'] {
+  --theme-background: oklch(from var(--tint) 0.99 calc(c * 0.1) h);
+  --theme-background-modal: oklch(from var(--tint) 0.94 calc(c * 0.12) h);
+  --theme-background-modal-footer: oklch(from var(--tint) 0.9 calc(c * 0.2) h);
+  --theme-background-input: oklch(from var(--tint) 0.97 calc(c * 0.08) h);
+  --theme-border: oklch(from var(--tint) 0.9 calc(c * 0.2) h);
+  --theme-border-subdued: oklch(from var(--tint) 0.92 calc(c * 0.15) h);
+  --theme-text: oklch(from var(--tint) 0.2 calc(c * 0.3) h);
+  --theme-button: oklch(from var(--tint) 0.2 calc(c * 0.3) h);
+  --theme-button-text: oklch(from var(--tint) 0.99 calc(c * 0.1) h);
+  --theme-button-foreground: oklch(from var(--tint) 0.92 calc(c * 0.15) h);
+  --theme-button-background: oklch(from var(--tint) 0.9 calc(c * 0.2) h);
+  --theme-focused-foreground: oklch(from var(--tint) 0.65 c h);
+  --theme-focused-foreground-subdued: oklch(from var(--tint) 0.65 c h / 0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  body.theme-system[class*='tint-'] {
+    --theme-background: oklch(from var(--tint) 0.15 calc(c * 0.2) h);
+    --theme-background-modal: oklch(from var(--tint) 0.3 calc(c * 0.2) h);
+    --theme-background-modal-footer: oklch(from var(--tint) 0.25 calc(c * 0.22) h);
+    --theme-background-input: oklch(from var(--tint) 0.35 calc(c * 0.18) h);
+    --theme-border: oklch(from var(--tint) 0.45 calc(c * 0.25) h);
+    --theme-border-subdued: oklch(from var(--tint) 0.45 calc(c * 0.25) h / 0.6);
+    --theme-text: oklch(from var(--tint) 0.88 calc(c * 0.2) h);
+    --theme-button: oklch(from var(--tint) 0.88 calc(c * 0.2) h);
+    --theme-button-text: oklch(from var(--tint) 0.15 calc(c * 0.2) h);
+    --theme-button-foreground: oklch(from var(--tint) 0.35 calc(c * 0.25) h);
+    --theme-button-background: oklch(from var(--tint) 0.3 calc(c * 0.2) h);
+    --theme-focused-foreground: oklch(from var(--tint) 0.7 c h);
+    --theme-focused-foreground-subdued: oklch(from var(--tint) 0.7 c h / 0.5);
+  }
 }
 
 body.theme-green {

--- a/utils/auth-session.ts
+++ b/utils/auth-session.ts
@@ -5,6 +5,7 @@ import { NextResponse } from 'next/server';
 
 import { AppPermission, AppRole, getRolePermissions, isAppRole, normalizeAppRole, roleHasPermission } from '@utils/authz';
 import { dbQuery } from '@utils/db';
+import { ThemePreferences, normalizeThemePreferences } from '@utils/theme-preferences';
 
 const SESSION_COOKIE = 'session';
 const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
@@ -16,6 +17,8 @@ interface RawSessionRow {
   role: string;
   is_active: boolean;
   assumed_role?: string | null;
+  theme_mode?: string | null;
+  theme_tint?: string | null;
   expires_at: string;
 }
 
@@ -26,6 +29,7 @@ export interface AppSession {
   role: AppRole;
   effectiveRole: AppRole;
   assumedRole: AppRole | null;
+  themePreferences: ThemePreferences;
   permissions: AppPermission[];
   expiresAt: string;
 }
@@ -55,6 +59,10 @@ function mapRawSession(row: RawSessionRow): AppSession {
     role,
     effectiveRole,
     assumedRole,
+    themePreferences: normalizeThemePreferences({
+      mode: row.theme_mode,
+      tint: row.theme_tint,
+    }),
     permissions: getRolePermissions(effectiveRole),
     expiresAt: row.expires_at,
   };
@@ -75,7 +83,9 @@ async function loadSessionByToken(sessionToken: string): Promise<AppSession | nu
           s.expires_at,
           u.username,
           u.role,
-          u.is_active
+          u.is_active,
+          u.theme_mode,
+          u.theme_tint
         from auth_sessions s
         join users u on u.id = s.user_id
         where s.token_hash = $1
@@ -85,8 +95,10 @@ async function loadSessionByToken(sessionToken: string): Promise<AppSession | nu
       [tokenHash]
     );
   } catch (error: any) {
-    // Backward compatibility for pre-migration schemas without auth_sessions.assumed_role.
-    if (error?.code !== '42703' || !String(error?.message || '').includes('assumed_role')) {
+    const message = String(error?.message || '');
+
+    // Backward compatibility for pre-migration schemas without auth_sessions.assumed_role or users theme preference columns.
+    if (error?.code !== '42703' || (!message.includes('assumed_role') && !message.includes('theme_mode') && !message.includes('theme_tint'))) {
       throw error;
     }
 
@@ -99,7 +111,9 @@ async function loadSessionByToken(sessionToken: string): Promise<AppSession | nu
           s.expires_at,
           u.username,
           u.role,
-          u.is_active
+          u.is_active,
+          null::text as theme_mode,
+          null::text as theme_tint
         from auth_sessions s
         join users u on u.id = s.user_id
         where s.token_hash = $1

--- a/utils/session-client.ts
+++ b/utils/session-client.ts
@@ -1,4 +1,5 @@
 import { AppPermission, AppRole } from '@utils/authz';
+import { ThemePreferences } from '@utils/theme-preferences';
 
 export interface CurrentSessionUser {
   id: string;
@@ -6,6 +7,7 @@ export interface CurrentSessionUser {
   role: AppRole;
   effectiveRole: AppRole;
   assumedRole: AppRole | null;
+  themePreferences: ThemePreferences;
   permissions: AppPermission[];
   basePermissions: AppPermission[];
   canOverrideSessionRole: boolean;

--- a/utils/theme-preferences-server.ts
+++ b/utils/theme-preferences-server.ts
@@ -1,0 +1,97 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+import { dbQuery } from '@utils/db';
+import { DEFAULT_THEME_PREFERENCES, ThemePreferences, normalizeThemePreferences } from '@utils/theme-preferences';
+
+const THEME_PREFERENCES_COOKIE = 'alfab-theme-preferences';
+const THEME_PREFERENCES_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+interface ThemePreferenceRow {
+  theme_mode: string | null;
+  theme_tint: string | null;
+}
+
+function serializeThemePreferences(themePreferences: ThemePreferences): string {
+  return `${themePreferences.mode}|${themePreferences.tint}`;
+}
+
+function parseThemePreferences(value: string | null | undefined): ThemePreferences {
+  if (!value) {
+    return DEFAULT_THEME_PREFERENCES;
+  }
+
+  const [mode, tint] = value.split('|');
+  return normalizeThemePreferences({ mode, tint });
+}
+
+export async function readThemePreferencesFromCookie(): Promise<ThemePreferences> {
+  const cookieStore = await cookies();
+  return parseThemePreferences(cookieStore.get(THEME_PREFERENCES_COOKIE)?.value);
+}
+
+export function applyThemePreferencesCookie(response: NextResponse, themePreferences: ThemePreferences): void {
+  response.cookies.set({
+    name: THEME_PREFERENCES_COOKIE,
+    value: serializeThemePreferences(themePreferences),
+    httpOnly: true,
+    path: '/',
+    sameSite: 'strict',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: THEME_PREFERENCES_TTL_SECONDS,
+  });
+}
+
+export function clearThemePreferencesCookie(response: NextResponse): void {
+  response.cookies.set({
+    name: THEME_PREFERENCES_COOKIE,
+    value: '',
+    httpOnly: true,
+    path: '/',
+    sameSite: 'strict',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 0,
+  });
+}
+
+export async function loadUserThemePreferences(userId: string): Promise<ThemePreferences> {
+  try {
+    const result = await dbQuery<ThemePreferenceRow>(
+      `
+        select theme_mode, theme_tint
+        from users
+        where id = $1
+        limit 1
+      `,
+      [userId]
+    );
+
+    if (!result.rowCount) {
+      return DEFAULT_THEME_PREFERENCES;
+    }
+
+    const row = result.rows[0];
+    return normalizeThemePreferences({
+      mode: row.theme_mode,
+      tint: row.theme_tint,
+    });
+  } catch (error: any) {
+    if (error?.code === '42703') {
+      return DEFAULT_THEME_PREFERENCES;
+    }
+
+    throw error;
+  }
+}
+
+export async function saveUserThemePreferences(userId: string, themePreferences: ThemePreferences): Promise<void> {
+  await dbQuery(
+    `
+      update users
+      set theme_mode = $1,
+          theme_tint = $2
+      where id = $3
+    `,
+    [themePreferences.mode, themePreferences.tint, userId]
+  );
+}

--- a/utils/theme-preferences.ts
+++ b/utils/theme-preferences.ts
@@ -1,0 +1,89 @@
+export const THEME_MODE_VALUES = ['light', 'dark', 'system'] as const;
+export const THEME_TINT_VALUES = ['none', 'blue', 'green', 'orange', 'purple', 'red', 'yellow', 'pink'] as const;
+
+export type ThemeMode = (typeof THEME_MODE_VALUES)[number];
+export type ThemeTint = (typeof THEME_TINT_VALUES)[number];
+
+export interface ThemePreferences {
+  mode: ThemeMode;
+  tint: ThemeTint;
+}
+
+export interface ThemePreferenceInput {
+  mode?: string | null;
+  tint?: string | null;
+}
+
+export const DEFAULT_THEME_PREFERENCES: ThemePreferences = {
+  mode: 'light',
+  tint: 'none',
+};
+
+export const THEME_MODE_OPTIONS: Array<{ value: ThemeMode; label: string }> = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+];
+
+export const THEME_TINT_OPTIONS: Array<{ value: ThemeTint; label: string }> = [
+  { value: 'none', label: 'None' },
+  { value: 'blue', label: 'Blue' },
+  { value: 'green', label: 'Green' },
+  { value: 'orange', label: 'Orange' },
+  { value: 'purple', label: 'Purple' },
+  { value: 'red', label: 'Red' },
+  { value: 'yellow', label: 'Yellow' },
+  { value: 'pink', label: 'Pink' },
+];
+
+export function isThemeMode(value: unknown): value is ThemeMode {
+  return typeof value === 'string' && THEME_MODE_VALUES.includes(value as ThemeMode);
+}
+
+export function isThemeTint(value: unknown): value is ThemeTint {
+  return typeof value === 'string' && THEME_TINT_VALUES.includes(value as ThemeTint);
+}
+
+export function normalizeThemePreferences(value: ThemePreferenceInput | null | undefined): ThemePreferences {
+  return {
+    mode: isThemeMode(value?.mode) ? value.mode : DEFAULT_THEME_PREFERENCES.mode,
+    tint: isThemeTint(value?.tint) ? value.tint : DEFAULT_THEME_PREFERENCES.tint,
+  };
+}
+
+export function themeModeToClassName(mode: ThemeMode): string {
+  return `theme-${mode}`;
+}
+
+export function themeTintToClassName(tint: ThemeTint): string {
+  return tint === 'none' ? '' : `tint-${tint}`;
+}
+
+export function themePreferencesToBodyClassName(themePreferences: ThemePreferences): string {
+  return [themeModeToClassName(themePreferences.mode), themeTintToClassName(themePreferences.tint)].filter(Boolean).join(' ');
+}
+
+export function applyThemePreferencesToDocument(themePreferences: ThemePreferences): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const body = document.body;
+
+  body.classList.forEach((className) => {
+    if (className.startsWith('theme-') || className.startsWith('tint-')) {
+      body.classList.remove(className);
+    }
+  });
+
+  const className = themePreferencesToBodyClassName(themePreferences);
+  if (!className) {
+    return;
+  }
+
+  className.split(' ').forEach((token) => {
+    if (token) {
+      body.classList.add(token);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add server and client theme preference plumbing so theme mode and tint persist per user
- apply saved theme classes from the app layout/provider and remove the static `/examples` override that forced the default theme
- update settings controls and auth flows so Light, Dark, and System selections survive navigation, reload, and sign-in changes

## Testing
- `npm run typecheck`
- `npm run build`
- Puppeteer runtime validation with mocked `/api/me` responses because the local worker has no `DATABASE_URL`
  - `nick`: `Light / Purple` persisted across `/settings` -> reload -> `/examples`
  - `superadmin`: `Dark / Green` persisted independently
  - `System / Purple`: `--theme-background` changed between light and dark media modes while the tint stayed applied

## Manual QA Plan
- Sign in as one user, open `/settings`, choose a theme mode and tint, then navigate to another app page and reload; the same appearance should remain active.
- Sign in as another user, choose a different mode and tint, then switch back; each user should keep their own saved combination.
- Choose `System` mode and confirm the app follows the current OS light/dark preference while keeping the selected tint.
