### PR TITLE
Move settings into account navigation

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -19,6 +19,7 @@ import { useThemePreferences } from '@components/ThemeProvider';
 
 import { CurrentSessionUser, fetchCurrentSessionUser } from '@utils/session-client';
 import { THEME_MODE_OPTIONS, THEME_TINT_OPTIONS } from '@utils/theme-preferences';
+import { APP_ACCOUNT_SECTION_ITEMS } from '@utils/app-navigation';
 
 const navigationItems = APP_NAVIGATION_ITEMS;
 
@@ -80,9 +81,9 @@ export default function AccountSettingsPage() {
       previewPixelSRC="/pixel.gif"
       logo="⚙"
       navigationItems={navigationItems}
-      navLabel="USER SETTINGS"
-      navRight={<ActionButton onClick={() => router.push('/settings')}>GO TO COSTING</ActionButton>}
-      heading="USER SETTINGS"
+      navLabel="APPEARANCE"
+      heading="APPEARANCE"
+      sectionNavigationItems={APP_ACCOUNT_SECTION_ITEMS}
       badge={badgeText}
       sidebarWidthCh={48}
       sidebarMobileOrder="top"

--- a/app/account/team/page.tsx
+++ b/app/account/team/page.tsx
@@ -18,6 +18,7 @@ import TableRow from '@components/TableRow';
 import Text from '@components/Text';
 
 import { APP_ROLES, AppRole } from '@utils/authz';
+import { APP_ACCOUNT_SECTION_ITEMS } from '@utils/app-navigation';
 import { CurrentSessionUser, fetchCurrentSessionUser } from '@utils/session-client';
 
 interface ManagedUser {
@@ -342,9 +343,9 @@ export default function TeamAccessPage() {
       previewPixelSRC="/pixel.gif"
       logo="⚙"
       navigationItems={navigationItems}
-      navLabel="TEAM ACCESS"
-      navRight={<ActionButton onClick={() => router.push('/account')}>BACK TO USER SETTINGS</ActionButton>}
-      heading="TEAM ACCESS"
+      navLabel="TEAM"
+      heading="TEAM"
+      sectionNavigationItems={APP_ACCOUNT_SECTION_ITEMS}
       badge={badgeText}
       sidebarWidthCh={52}
       sidebarMobileOrder="top"
@@ -477,7 +478,7 @@ export default function TeamAccessPage() {
         },
         {
           hotkey: '⌘+B',
-          body: 'Account',
+          body: 'Appearance',
           onClick: () => router.push('/account'),
         },
       ]}

--- a/app/settings/billing/page.tsx
+++ b/app/settings/billing/page.tsx
@@ -16,6 +16,7 @@ import Table from '@components/Table';
 import TableColumn from '@components/TableColumn';
 import TableRow from '@components/TableRow';
 import Text from '@components/Text';
+import { APP_ACCOUNT_SECTION_ITEMS } from '@utils/app-navigation';
 
 const navigationItems = APP_NAVIGATION_ITEMS;
 
@@ -202,9 +203,9 @@ export default function BillingSettingsPage() {
       previewPixelSRC="/pixel.gif"
       logo="⚙"
       navigationItems={navigationItems}
-      navLabel="HOSTING BILLING"
-      navRight={<ActionButton onClick={() => router.push('/settings')}>BACK TO COSTING SETTINGS</ActionButton>}
-      heading="HOSTING BILLING"
+      navLabel="BILLING"
+      heading="BILLING"
+      sectionNavigationItems={APP_ACCOUNT_SECTION_ITEMS}
       badge={badgeLabel}
       sidebarWidthCh={46}
       sidebarMobileOrder="top"
@@ -289,7 +290,7 @@ export default function BillingSettingsPage() {
         },
         {
           hotkey: '⌘+B',
-          body: 'Back',
+          body: 'Costing',
           onClick: () => router.push('/settings'),
         },
       ]}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -18,6 +18,7 @@ import TableRow from '@components/TableRow';
 import Text from '@components/Text';
 
 import { usePricing } from '@components/PricingProvider';
+import { APP_ACCOUNT_SECTION_ITEMS } from '@utils/app-navigation';
 import { EdgeworkType, GlassThickness, GlassType } from '@utils/calculations';
 
 const navigationItems = APP_NAVIGATION_ITEMS;
@@ -93,9 +94,10 @@ export default function PricingSettings() {
       previewPixelSRC="/pixel.gif"
       logo="⚙"
       navigationItems={navigationItems}
-      navLabel="COSTING SETTINGS"
+      navLabel="COSTING"
       navRight={<ActionButton onClick={() => router.push('/')}>BACK TO COSTING</ActionButton>}
-      heading="COSTING CONFIGURATION"
+      heading="COSTING"
+      sectionNavigationItems={APP_ACCOUNT_SECTION_ITEMS}
       badge={hasChanges ? 'UNSAVED CHANGES' : 'SAVED'}
       sidebarWidthCh={44}
       sidebarMobileOrder="top"

--- a/components/page/AppFrame.tsx
+++ b/components/page/AppFrame.tsx
@@ -11,6 +11,7 @@ import Grid from '@components/Grid';
 import Navigation from '@components/Navigation';
 import AppSectionNav from '@components/page/AppSectionNav';
 import AppSessionIndicator from '@components/page/AppSessionIndicator';
+import { AppSectionItem } from '@utils/app-navigation';
 
 interface NavigationItem {
   icon?: React.ReactNode;
@@ -40,6 +41,7 @@ interface AppFrameProps {
   actionItems?: FrameActionItem[];
   showThemeControls?: boolean;
   showSectionNavigation?: boolean;
+  sectionNavigationItems?: AppSectionItem[];
   showSessionIndicator?: boolean;
   sidebar?: React.ReactNode;
   sidebarAriaLabel?: string;
@@ -58,6 +60,7 @@ const AppFrame: React.FC<AppFrameProps> = ({
   actionItems = [],
   showThemeControls = false,
   showSectionNavigation = true,
+  sectionNavigationItems,
   showSessionIndicator = true,
   sidebar,
   sidebarAriaLabel = 'Page sidebar',
@@ -94,7 +97,7 @@ const AppFrame: React.FC<AppFrameProps> = ({
       <Grid className={styles.root}>
         <Navigation logo={logo} left={left} right={right} />
 
-        {showSectionNavigation ? <AppSectionNav /> : null}
+        {showSectionNavigation ? <AppSectionNav items={sectionNavigationItems} /> : null}
 
         {showThemeControls && <DefaultActionBar floating />}
 

--- a/components/page/AppSectionNav.tsx
+++ b/components/page/AppSectionNav.tsx
@@ -3,7 +3,7 @@
 import styles from '@components/page/AppSectionNav.module.scss';
 
 import ActionButton from '@components/ActionButton';
-import { APP_SECTION_ITEMS, AppSectionItem } from '@utils/app-navigation';
+import { APP_WORK_SECTION_ITEMS, AppSectionItem } from '@utils/app-navigation';
 import { usePathname, useRouter } from 'next/navigation';
 
 function isSelectedPath(pathname: string, item: AppSectionItem): boolean {
@@ -15,6 +15,10 @@ function isSelectedPath(pathname: string, item: AppSectionItem): boolean {
     return pathname === '/doors/new';
   }
 
+  if (item.href === '/account') {
+    return pathname === '/account' || (pathname.startsWith('/account/') && !pathname.startsWith('/account/team'));
+  }
+
   if (item.href === '/settings') {
     return pathname === '/settings' || (pathname.startsWith('/settings/') && !pathname.startsWith('/settings/billing'));
   }
@@ -22,13 +26,17 @@ function isSelectedPath(pathname: string, item: AppSectionItem): boolean {
   return pathname === item.href || pathname.startsWith(`${item.href}/`);
 }
 
-export default function AppSectionNav() {
+interface AppSectionNavProps {
+  items?: AppSectionItem[];
+}
+
+export default function AppSectionNav({ items = APP_WORK_SECTION_ITEMS }: AppSectionNavProps) {
   const router = useRouter();
   const pathname = usePathname();
 
   return (
-    <section className={styles.root} aria-label="Primary navigation">
-      {APP_SECTION_ITEMS.map((item) => (
+    <section className={styles.root} aria-label="Section navigation">
+      {items.map((item) => (
         <ActionButton key={item.href} isSelected={isSelectedPath(pathname, item)} onClick={() => router.push(item.href)}>
           {item.label}
         </ActionButton>

--- a/components/page/AppSessionIndicator.tsx
+++ b/components/page/AppSessionIndicator.tsx
@@ -69,8 +69,23 @@ export default function AppSessionIndicator() {
     ? [
         {
           icon: '⊹',
-          children: 'USER SETTINGS',
+          children: 'Appearance',
           href: '/account',
+        },
+        {
+          icon: '⊹',
+          children: 'Costing',
+          href: '/settings',
+        },
+        {
+          icon: '⊹',
+          children: 'Team',
+          href: '/account/team',
+        },
+        {
+          icon: '⊹',
+          children: 'Billing',
+          href: '/settings/billing',
         },
         {
           icon: '⊹',

--- a/utils/app-navigation.ts
+++ b/utils/app-navigation.ts
@@ -10,8 +10,6 @@ export const APP_NAVIGATION_ITEMS: AppNavigationItem[] = [
   { icon: '⊹', children: 'New Purchase Order', href: '/doors/new' },
   { icon: '⊹', children: 'Calculator', href: '/doors/quote' },
   { icon: '⊹', children: 'Customers & Products', href: '/doors/clients' },
-  { icon: '⊹', children: 'Costing Settings', href: '/settings' },
-  { icon: '⊹', children: 'Hosting Billing', href: '/settings/billing' },
   { icon: '⊹', children: 'Component Library', href: '/examples' },
 ];
 
@@ -20,11 +18,16 @@ export interface AppSectionItem {
   label: string;
 }
 
-export const APP_SECTION_ITEMS: AppSectionItem[] = [
+export const APP_WORK_SECTION_ITEMS: AppSectionItem[] = [
   { href: '/doors', label: 'Dashboard' },
   { href: '/doors/new', label: 'New Order' },
   { href: '/doors/quote', label: 'Calculator' },
   { href: '/doors/clients', label: 'Customers' },
+];
+
+export const APP_ACCOUNT_SECTION_ITEMS: AppSectionItem[] = [
+  { href: '/account', label: 'Appearance' },
   { href: '/settings', label: 'Costing' },
+  { href: '/account/team', label: 'Team' },
   { href: '/settings/billing', label: 'Billing' },
 ];


### PR DESCRIPTION
## Summary
- remove costing and billing from the main app header navigation
- add a dedicated settings tab bar with Appearance, Costing, Team, and Billing across the account/settings pages
- move settings entry points into the user menu so they remain accessible without crowding the work nav

## Verification
- npm run typecheck
- npm run build
